### PR TITLE
Require and verify current password before allowing password changes

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -158,28 +158,49 @@ def update_user():
     user_resource = users_resource.user(current_user.id)
 
     if request.method == 'POST':
+        form_type = request.form.get('form_type', 'profile')
         email = request.form.get('email')
         password = request.form.get('password')
         name = request.form.get('name')
         user_class = request.form.get('class')
         confirm_password = request.form.get('confirm_password')
+        current_password = request.form.get('current_password')
 
         user_data = {}
 
-        if email and email.strip():
-            user_data['email'] = email.strip()
+        if form_type == 'profile':
+            if email and email.strip():
+                user_data['email'] = email.strip()
 
-        if name and name.strip():
-            user_data['name'] = name.strip()
+            if name and name.strip():
+                user_data['name'] = name.strip()
 
-        if user_class and user_class.strip():
-            user_data['user_class'] = user_class.strip()
+            if user_class and user_class.strip():
+                user_data['user_class'] = user_class.strip()
 
-        if password:
+        elif form_type == 'password':
+            if not current_password:
+                flash("Current password is required", "error")
+                return render_template('editprofile.html')
+
+            try:
+                users_resource.authenticate(current_user.email, current_password)
+            except ValueError:
+                flash("Current password is incorrect", "error")
+                return render_template('editprofile.html')
+
+            if not password:
+                flash("New password is required", "error")
+                return render_template('editprofile.html')
+
             if password != confirm_password:
                 flash("Passwords do not match", "error")
-                return render_template('updateuser.html')
+                return render_template('editprofile.html')
             user_data['password'] = password
+
+        else:
+            flash("Invalid update request", "error")
+            return render_template('editprofile.html')
 
         if not user_data:
             flash("No valid fields provided for update", "error")


### PR DESCRIPTION
### Motivation
- The edit profile flow allowed users to submit a new password without validating the current password, making the verification step ineffective.
- Password update logic was mixed into general profile updates which risked incorrect validation and UX inconsistencies.
- The goal is to enforce server-side current-password verification against the database before accepting a password change.

### Description
- Added branching in `auth.update_user` driven by the `form_type` field so profile edits (`form_type=profile`) and password changes (`form_type=password`) are handled separately in `app/routes/auth.py`.
- For password updates, require a `current_password` and verify it by calling `users_resource.authenticate(current_user.email, current_password)` before accepting the new password.
- Enforced additional checks for password updates: require a new password, ensure confirmation matches, and return clear error flashes rendering `editprofile.html` on failure.
- Standardized error paths and responses so invalid form types or missing fields are rejected with an explanatory flash message.

### Testing
- Ran `python -m compileall app/routes/auth.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db97e429748329b02559df99d433a8)