### PR TITLE
Railway deployment and devcontainer update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+# Install curl, bash, and pip.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash curl python3-pip \
+    && python3 -m pip install --upgrade pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Railway CLI first.
+RUN curl -fsSL https://cli.new | bash
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,14 @@
 {
-    "postCreateCommand": "/home/codespace/.python/current/bin/pip install psycopg2-binary python-dotenv flask flask_login resend",
+    "name": "Python 3.12",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r requirements.txt",
     "postStartCommand": "git pull origin $(git branch --show-current) && git merge origin/dev",
     "customizations": {
         "vscode": {
             "settings": {
-                "python.defaultInterpreterPath": "/home/codespace/.python/current/bin/python"
+                "python.defaultInterpreterPath": "/usr/local/bin/python3"
             },
             "extensions": [
                 "ms-python.python"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-Flask
-flask-login
-psycopg2-binary
-python-dotenv
-resend
-python-dateutil
+Flask==3.0.0
+Flask-Login==0.6.3
+python-dotenv==1.0.0
+psycopg2-binary==2.9.7
+requests==2.31.0
+resend==0.7.0
+python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.9.7
 requests==2.31.0
 resend==0.7.0
 python-dateutil==2.8.2
+gunicorn==21.2.0


### PR DESCRIPTION
This PR sets up the codespace for Railway deployment.

Deployment URL: https://activityalligator-dev.up.railway.app/

The deployment is redeployed on every push to `dev` branch. I recommend you set up CI tests to ensure that pushes which will cause deployment to fail are blocked.

The devcontainer config has also been refactored to do the following:
- install pip and railway
- lock python package versions in requirements.txt
- install from requirements.txt properly using pip

Using the railway CLI requires `RAILWAY_TOKEN` environment variable. This is set as a codespace secret in the repository, accessible to repo admins only.

Usage:

```bash
railway logs --service Capstone-Project-2527
```